### PR TITLE
further updates to addition of ExecutionJournal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,6 @@ dependencies = [
  "chrono",
  "criterion",
  "datasize",
- "derive_more",
  "hex-buffer-serde 0.2.2",
  "hex_fmt",
  "hostname",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -17,7 +17,6 @@ casper-hashing = { version = "1.0.0", path = "../hashing" }
 casper-types = { version = "1.0.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
-derive_more = "0.99"
 hex-buffer-serde = "0.2.1"
 hex_fmt = "0.3.0"
 hostname = "0.3.0"

--- a/execution_engine/src/core/engine_state/execution_effect.rs
+++ b/execution_engine/src/core/engine_state/execution_effect.rs
@@ -16,31 +16,22 @@ pub struct ExecutionEffect {
     pub transforms: AdditiveMap<Key, Transform>,
 }
 
-impl ExecutionEffect {
-    /// Creates a new [`ExecutionEffect`].
-    pub fn new(ops: AdditiveMap<Key, Op>, transforms: AdditiveMap<Key, Transform>) -> Self {
-        ExecutionEffect { ops, transforms }
-    }
-}
-
 impl From<ExecutionJournal> for ExecutionEffect {
     fn from(journal: ExecutionJournal) -> Self {
         let mut ops = AdditiveMap::new();
         let mut transforms = AdditiveMap::new();
-        let journal: Vec<(Key, Transform)> = journal.into();
         for (key, transform) in journal.into_iter() {
-            let op = match transform {
-                Transform::Failure(_) => continue,
-                Transform::Identity => Op::Read,
-                Transform::Write(_) => Op::Write,
+            match transform {
+                Transform::Failure(_) => (),
+                Transform::Identity => ops.insert_add(key, Op::Read),
+                Transform::Write(_) => ops.insert_add(key, Op::Write),
                 Transform::AddInt32(_)
                 | Transform::AddUInt64(_)
                 | Transform::AddUInt128(_)
                 | Transform::AddUInt256(_)
                 | Transform::AddUInt512(_)
-                | Transform::AddKeys(_) => Op::Add,
+                | Transform::AddKeys(_) => ops.insert_add(key, Op::Add),
             };
-            ops.insert_add(key, op);
             transforms.insert_add(key, transform);
         }
 
@@ -51,7 +42,6 @@ impl From<ExecutionJournal> for ExecutionEffect {
 impl From<ExecutionJournal> for AdditiveMap<Key, Transform> {
     fn from(journal: ExecutionJournal) -> Self {
         let mut transforms = AdditiveMap::new();
-        let journal: Vec<(Key, Transform)> = journal.into();
         for (key, transform) in journal.into_iter() {
             transforms.insert_add(key, transform);
         }

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -807,7 +807,7 @@ where
     }
 
     pub(crate) fn finalize(self) -> ExecutionEffect {
-        self.tracking_copy.borrow_mut().effect()
+        self.tracking_copy.borrow().effect()
     }
 
     pub(crate) fn create_mint(&mut self) -> Result<ContractHash, GenesisError> {

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1117,8 +1117,7 @@ where
         }
 
         if session_result.is_success() {
-            session_result =
-                session_result.with_journal(tracking_copy.borrow_mut().execution_journal())
+            session_result = session_result.with_journal(tracking_copy.borrow().execution_journal())
         }
 
         let mut execution_result_builder = ExecutionResultBuilder::new();

--- a/execution_engine/src/core/execution/tests.rs
+++ b/execution_engine/src/core/execution/tests.rs
@@ -46,7 +46,7 @@ fn on_fail_charge_with_action() {
     let f = || {
         let input: Result<(), Error> = Err(Error::GasLimit);
         let transfers = Vec::default();
-        let journal: ExecutionJournal = vec![(Key::Hash([42u8; 32]), Transform::Identity)].into();
+        let journal = ExecutionJournal::new(vec![(Key::Hash([42u8; 32]), Transform::Identity)]);
 
         on_fail_charge!(input, Gas::new(U512::from(456)), journal, transfers);
         ExecutionResult::Success {

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -576,12 +576,12 @@ where
 
     /// Returns current effects of a tracking copy.
     pub fn effect(&self) -> ExecutionEffect {
-        self.tracking_copy.borrow_mut().effect()
+        self.tracking_copy.borrow().effect()
     }
 
     /// Returns an `ExecutionJournal`.
     pub fn execution_journal(&self) -> ExecutionJournal {
-        self.tracking_copy.borrow_mut().execution_journal()
+        self.tracking_copy.borrow().execution_journal()
     }
 
     /// Returns list of transfers.

--- a/execution_engine/src/shared.rs
+++ b/execution_engine/src/shared.rs
@@ -1,6 +1,5 @@
 //! The shared logic of the execution engine.
 pub mod additive_map;
-#[macro_use]
 pub mod execution_journal;
 pub mod host_function_costs;
 pub mod logging;

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable changes to this project will be documented in this file.  The format
   * `[gossip][gossip_request_timeout]`
   * `[gossip][get_remainder_timeout]`
   * `[fetcher][get_from_peer_timeout]`
-  * Execution transforms are ordered by insertion order.
+* Execution transforms are ordered by insertion order.
 
 ### Removed
 * The unofficial support for nix-related derivations and support tooling has been removed.

--- a/node/src/components/contract_runtime/announcements.rs
+++ b/node/src/components/contract_runtime/announcements.rs
@@ -1,18 +1,17 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt::{self, Display, Formatter},
 };
 
 use serde::Serialize;
 
+use casper_execution_engine::shared::execution_journal::ExecutionJournal;
 use casper_types::{EraId, ExecutionEffect, ExecutionResult, PublicKey, U512};
 
 use crate::{
     effect::{announcements::LinearChainBlock, EffectBuilder},
     types::{Block, DeployHash, DeployHeader},
 };
-use casper_execution_engine::shared::execution_journal::ExecutionJournal;
-use std::collections::BTreeMap;
 
 /// A ContractRuntime announcement.
 #[derive(Debug, Serialize)]
@@ -85,7 +84,7 @@ pub(super) async fn step_success<REv>(
     effect_builder
         .schedule_regular(ContractRuntimeAnnouncement::StepSuccess {
             era_id,
-            execution_effect: execution_journal.into(),
+            execution_effect: (&execution_journal).into(),
         })
         .await
 }

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -172,7 +172,7 @@ fn commit_execution_effects(
         .into_iter()
         .exactly_one()
         .map_err(|_| BlockExecutionError::MoreThanOneExecutionResult)?;
-    let json_execution_result = ExecutionResult::from(ee_execution_result.clone());
+    let json_execution_result = ExecutionResult::from(&ee_execution_result);
 
     let execution_effect: AdditiveMap<Key, Transform> = match ee_execution_result {
         EngineExecutionResult::Success {

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -1,11 +1,12 @@
 use std::collections::{BTreeMap, HashMap};
 
-use casper_execution_engine::core::engine_state::GetEraValidatorsRequest;
+use casper_execution_engine::{
+    core::engine_state::GetEraValidatorsRequest, shared::execution_journal::ExecutionJournal,
+};
 use casper_hashing::Digest;
 use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey, U512};
 
 use crate::types::{Block, DeployHash, DeployHeader};
-use casper_execution_engine::shared::execution_journal::ExecutionJournal;
 
 /// Request for validator weights for a specific era.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
A few nitpicks, but the two significant changes are:
* fixed a bug in `impl From<ExecutionJournal> for ExecutionEffect` where `Transform::Failure(_) => continue` would cause the transform in question to _not_ be added to `transforms` (please double check the fix is valid)
* removed `ops` from `TrackingCopy`