### PR TITLE
CI: Build contracts prior to run cargo test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,6 +107,7 @@ steps:
   image: casperlabs/node-build-u1804
   commands:
   - make setup
+  - make build-contracts
   - make test CARGO_FLAGS=--release
   - make test-contracts CARGO_FLAGS=--release
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "named-dictionary-test"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "named-keys"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine_testing/tests/src/test/contract_api/mod.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mod.rs
@@ -10,6 +10,7 @@ mod get_phase;
 mod list_named_keys;
 mod main_purse;
 mod mint_purse;
+mod named_dictionaries;
 mod revert;
 mod subcall;
 mod transfer;

--- a/execution_engine_testing/tests/src/test/contract_api/named_dictionaries.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/named_dictionaries.rs
@@ -1,0 +1,33 @@
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_types::{runtime_args, RuntimeArgs};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+#[test]
+fn named_dictionaries_should_work_as_expected() {
+    // Types from `smart_contracts/contracts/test/named-dictionary-test/src/main.rs`.
+    type DictIndex = u8;
+    type KeySeed = u8;
+    type Value = u8;
+
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let puts: Vec<(DictIndex, KeySeed, Value)> = (0..1_000)
+        .map(|_| (rng.gen_range(0..9), rng.gen_range(0..20), rng.gen()))
+        .collect();
+
+    let builder = &mut InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder
+        .exec(
+            ExecuteRequestBuilder::standard(
+                *DEFAULT_ACCOUNT_ADDR,
+                "named-dictionary-test.wasm",
+                runtime_args! { "puts" => puts },
+            )
+            .build(),
+        )
+        .expect_success();
+}

--- a/smart_contracts/contract/src/contract_api/storage.rs
+++ b/smart_contracts/contract/src/contract_api/storage.rs
@@ -422,3 +422,27 @@ pub fn dictionary_put<V: CLTyped + ToBytes>(
 
     result.unwrap_or_revert()
 }
+
+fn get_named_uref(name: &str) -> URef {
+    match runtime::get_key(name).unwrap_or_revert_with(ApiError::GetKey) {
+        Key::URef(uref) => uref,
+        _ => revert(ApiError::UnexpectedKeyVariant),
+    }
+}
+
+/// Gets a value out of a named dictionary.
+pub fn named_dictionary_get<V: CLTyped + FromBytes>(
+    dictionary_name: &str,
+    dictionary_item_key: &str,
+) -> Result<Option<V>, bytesrepr::Error> {
+    dictionary_get(get_named_uref(dictionary_name), dictionary_item_key)
+}
+
+/// Writes a value in a named dictionary.
+pub fn named_dictionary_put<V: CLTyped + ToBytes>(
+    dictionary_name: &str,
+    dictionary_item_key: &str,
+    value: V,
+) {
+    dictionary_put(get_named_uref(dictionary_name), dictionary_item_key, value)
+}

--- a/smart_contracts/contracts/test/named-dictionary-test/Cargo.toml
+++ b/smart_contracts/contracts/test/named-dictionary-test/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "named-dictionary-test"
+version = "0.1.0"
+authors = ["Luís Fernando Schultz Xavier da Silveira <luis@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "named-dictionary-test"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/named-dictionary-test/src/main.rs
+++ b/smart_contracts/contracts/test/named-dictionary-test/src/main.rs
@@ -1,0 +1,55 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
+use casper_contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+
+type DictIndex = u8; // Must fit into `usize`.
+type KeySeed = u8;
+type Value = u8;
+const DICTIONARY_NAMES: &[&str] = &[
+    "the", "quick", "brown", "fox", "jumps", "over", "the_", "lazy", "dog",
+];
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let puts: Vec<(DictIndex, KeySeed, Value)> = runtime::get_named_arg("puts");
+
+    for name in DICTIONARY_NAMES {
+        let _ = storage::new_dictionary(name).unwrap_or_revert();
+    }
+
+    let mut maps: Vec<BTreeMap<String, Value>> = (0..DICTIONARY_NAMES.len())
+        .map(|_| BTreeMap::new())
+        .collect();
+    for (dict_index, key_seed, value) in puts {
+        let dict_index = dict_index as usize;
+        assert!(dict_index < DICTIONARY_NAMES.len());
+        let key = key_seed.to_string();
+        assert_eq!(
+            maps[dict_index].get(&key),
+            storage::named_dictionary_get(DICTIONARY_NAMES[dict_index], &key)
+                .unwrap_or_revert()
+                .as_ref()
+        );
+        storage::named_dictionary_put(DICTIONARY_NAMES[dict_index], &key, value);
+        maps[dict_index].insert(key, value);
+    }
+
+    for i in 0..DICTIONARY_NAMES.len() {
+        for (key, &value) in maps[i].iter() {
+            assert_eq!(
+                storage::named_dictionary_get(DICTIONARY_NAMES[i], key).unwrap_or_revert(),
+                Some(value)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds `make build-contracts` to drone step.
